### PR TITLE
fix array size

### DIFF
--- a/pulse-eco-v2-lorawan/pulse-eco-v2-lorawan.ino
+++ b/pulse-eco-v2-lorawan/pulse-eco-v2-lorawan.ino
@@ -174,7 +174,7 @@ void setup(void)
     digitalWrite(LED_BUILTIN, LOW);
 }
 
-byte packet[10];
+byte packet[11];
 char hexbuffer[3];
 
 int loopCycleCount = 0;


### PR DESCRIPTION
@hsilomedus 

I adjusted the array size of packet to 11, such that the last byte of the humidity doesn't crop off